### PR TITLE
bluenex/tpt-27-disable-payment-button-in-nmc-box

### DIFF
--- a/frontend/src/components/PaymentForm/CheckoutForm.js
+++ b/frontend/src/components/PaymentForm/CheckoutForm.js
@@ -80,7 +80,15 @@ const CheckoutForm = ({ onSubmit, onHideModal, isConfirmingPayment }) => {
   const elements = useElements()
 
   if (!elements || !stripe) {
-    return <LoadingView />
+    return (
+      <p>
+        <code>GATSBY_STRIPE_PUBLIC_KEY</code> is missing from <code>.env</code>.
+        <br />
+        <br />
+        To see the payment form properly, please at least add{" "}
+        <code>GATSBY_STRIPE_PUBLIC_KEY=""</code> to the <code>.env</code> file.
+      </p>
+    )
   }
 
   return (


### PR DESCRIPTION
I'm not sure what you mean by dark box. In my case, I got this loading screen:
![image](https://user-images.githubusercontent.com/11027706/138293709-347f7108-9742-4336-a677-38a4472a25b1.png)

So I changed it to:
![image](https://user-images.githubusercontent.com/11027706/138293728-ddc758e6-a69e-4742-8983-13b3e10e239a.png)

This only occurs when GATSBY_STRIPE_PUBLIC_KEY is not listed in .env. If it is listed with an empty string value, you should be able to see the checkout form to fill the card number. But it will be infinite load once you submit like this:
![image](https://user-images.githubusercontent.com/11027706/138293757-8399a820-69dd-4371-884a-d739052c3783.png)