### PR TITLE
bluenex/tpt-26-edit-profile-page-does-not-work-on-nmc

### DIFF
--- a/frontend/src/components/RegisterForm/index.js
+++ b/frontend/src/components/RegisterForm/index.js
@@ -204,7 +204,7 @@ const RegisterForm = ({ prevUserData, origin }) => {
       }
 
       const readyData = {
-        id: user.uid,
+        id: user?.uid,
         payload: preparedPayload,
         // payload: !isOptedOutMindMatching
         //   ? preparedPayload
@@ -249,7 +249,7 @@ const RegisterForm = ({ prevUserData, origin }) => {
           setIsSending(false)
         })
     },
-    [editProfileAPI, isPublic, origin, registerAPI, user.uid]
+    [editProfileAPI, isPublic, origin, registerAPI, user]
   )
 
   return (


### PR DESCRIPTION
The crash is due to `useCallback` dependencies has `user.uid` which is `null` on first load.